### PR TITLE
Define lifts for each transactable type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,19 @@ exception will be reported to the transactor's caller, instead of the normal
 result of the passed operation. Transactors make no effort to determine whether
 a failure during cleanup has actually reversed the transaction's side effects,
 and will not call `abort(context)` once `finish(context)` has been called.
+
+## Lifts
+
+Non-transactable functions can be embedded in transactor sequences using
+`lift`s for each transactable type. Every `lift` method produces a transactable
+which ignores its context and applies the lifted operation to the remaining
+arguments. This mechanism allows computation steps to be interleaved with
+transacted steps cleanly, without exiting the transaction context.
+
+The following types can be lifted:
+
+* `Runnable` can be lifted to `Action`.
+* `Consumer` can be lifted to `Sink`.
+* `Supplier` can be lifted to `Query`.
+* `Function` can be lifted to `Transform`.
+* `BiFunction` can be lifted to `Merge`.

--- a/src/main/java/com/loginbox/transactor/transactable/Action.java
+++ b/src/main/java/com/loginbox/transactor/transactable/Action.java
@@ -11,6 +11,20 @@ package com.loginbox.transactor.transactable;
 @FunctionalInterface
 public interface Action<C> {
     /**
+     * Lifts a Runnable task into an action over some context. The context will be ignored by the resulting action. This
+     * can be used to inject procedural steps such as logging into transactable sequences.
+     *
+     * @param task
+     *         the task to lift to an Action.
+     * @param <C>
+     *         the context type of the resulting action.
+     * @return an Action wrapping <var>task</var>.
+     */
+    public static <C> Action<C> lift(Runnable task) {
+        return context -> task.run();
+    }
+
+    /**
      * Apply the action to a context.
      *
      * @param context

--- a/src/main/java/com/loginbox/transactor/transactable/Merge.java
+++ b/src/main/java/com/loginbox/transactor/transactable/Merge.java
@@ -1,5 +1,7 @@
 package com.loginbox.transactor.transactable;
 
+import java.util.function.BiFunction;
+
 /**
  * A transactable transform. Given two values of type <var>M</var> and <var>N</var>, and a context of type <var>C</var>,
  * a merge produces a single result of type <var>O</var>.
@@ -17,7 +19,27 @@ package com.loginbox.transactor.transactable;
 @FunctionalInterface
 public interface Merge<C, M, N, O> {
     /**
-     * Merge <var>v0</var> and <var>v1</var> in the context of <var>context</var>.
+     * Lifts a non-transactable binary function into a merge. The resulting merge ignores its context, but can be
+     * composed with other transactables.
+     *
+     * @param function
+     *         the function to lift.
+     * @param <C>
+     *         the context type for the resulting merge.
+     * @param <M>
+     *         the first input type.
+     * @param <N>
+     *         the second input type.
+     * @param <O>
+     *         the merge's output type.
+     * @return a merge wrapping <var>function</var>.
+     */
+    public static <C, M, N, O> Merge<C, M, N, O> lift(BiFunction<? super M, ? super N, ? extends O> function) {
+        return (context, left, right) -> function.apply(left, right);
+    }
+
+    /**
+     * Merge <var>left</var> and <var>right</var> in the context of <var>context</var>.
      *
      * @param context
      *         the external context of the merge.
@@ -25,7 +47,7 @@ public interface Merge<C, M, N, O> {
      *         the first of the values to merge.
      * @param right
      *         the second of the values to merge.
-     * @return the result of merging these values..
+     * @return the result of merging these values.
      * @throws java.lang.Exception
      *         if the merge cannot be completed.
      */

--- a/src/main/java/com/loginbox/transactor/transactable/Query.java
+++ b/src/main/java/com/loginbox/transactor/transactable/Query.java
@@ -1,5 +1,7 @@
 package com.loginbox.transactor.transactable;
 
+import java.util.function.Supplier;
+
 /**
  * A transactable that obtains a value from a context.
  *
@@ -12,6 +14,22 @@ package com.loginbox.transactor.transactable;
 @FunctionalInterface
 public interface Query<C, R> {
     /**
+     * Lifts a Supplier into a Query over some context. The resulting query will ignore the context, but can be composed
+     * with other transactables.
+     *
+     * @param supplier
+     *         the supplier to lift.
+     * @param <C>
+     *         the context type of the resulting Query.
+     * @param <R>
+     *         the result type of the resulting query.
+     * @return a Query wrapping <var>supplier</var>.
+     */
+    public static <C, R> Query<C, R> lift(Supplier<? extends R> supplier) {
+        return context -> supplier.get();
+    }
+
+    /**
      * Fetches a value from a context.
      *
      * @param context
@@ -21,4 +39,6 @@ public interface Query<C, R> {
      *         if the query cannot be completed.
      */
     public R fetch(C context) throws Exception;
+
+
 }

--- a/src/main/java/com/loginbox/transactor/transactable/Sink.java
+++ b/src/main/java/com/loginbox/transactor/transactable/Sink.java
@@ -1,5 +1,7 @@
 package com.loginbox.transactor.transactable;
 
+import java.util.function.Consumer;
+
 /**
  * A transactable task that consumes a value in a context.
  *
@@ -11,6 +13,22 @@ package com.loginbox.transactor.transactable;
  */
 @FunctionalInterface
 public interface Sink<C, V> {
+    /**
+     * Lifts a Consumer into a Sink over some context. The resulting sink will ignore its context, but can be composed
+     * with other transactables.
+     *
+     * @param consumer
+     *         the consumer to lift.
+     * @param <C>
+     *         the type of the resulting sink's context.
+     * @param <V>
+     *         the type of values to consume.
+     * @return a Sink wrapping <var>consumer</var>.
+     */
+    public static <C, V> Sink<C, V> lift(Consumer<? super V> consumer) {
+        return (context, value) -> consumer.accept(value);
+    }
+
     /**
      * Consumes a value in the context.
      *

--- a/src/main/java/com/loginbox/transactor/transactable/Transform.java
+++ b/src/main/java/com/loginbox/transactor/transactable/Transform.java
@@ -1,5 +1,7 @@
 package com.loginbox.transactor.transactable;
 
+import java.util.function.Function;
+
 /**
  * A transactable transform. Given a value of type <var>I</var> and a context of type <var>C</var>, a transform produces
  * a result of type <var>O</var>.
@@ -14,6 +16,24 @@ package com.loginbox.transactor.transactable;
  */
 @FunctionalInterface
 public interface Transform<C, I, O> {
+    /**
+     * Lifts a non-transactable function into a transform. The resulting transform ignores its context, but can be
+     * composed with other transactables.
+     *
+     * @param function
+     *         the function to lift.
+     * @param <C>
+     *         the context type for the resulting transform.
+     * @param <I>
+     *         the transform's input type.
+     * @param <O>
+     *         the transform's output type.
+     * @return a transform wrapping <var>function</var>.
+     */
+    public static <C, I, O> Transform<C, I, O> lift(Function<? super I, ? extends O> function) {
+        return (context, input) -> function.apply(input);
+    }
+
     /**
      * Transform <var>value</var> in the context of <var>context</var>.
      *

--- a/src/test/java/com/loginbox/transactor/transactable/ActionLiftTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/ActionLiftTest.java
@@ -1,0 +1,40 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ActionLiftTest {
+    private final Context context = mock(Context.class);
+
+    private final Runnable task = mock(Runnable.class);
+    private final Action<Context> lifted = Action.lift(task);
+
+    @Test
+    public void executesTask() throws Exception {
+        lifted.execute(context);
+
+        verify(task).run();
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("task failed");
+        doThrow(taskFailed).when(task).run();
+
+        try {
+            lifted.execute(context);
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(task).run();
+    }
+}

--- a/src/test/java/com/loginbox/transactor/transactable/MergeLiftTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/MergeLiftTest.java
@@ -1,0 +1,46 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import org.junit.Test;
+
+import java.util.function.BiFunction;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class MergeLiftTest {
+    private final Context context = mock(Context.class);
+
+    @SuppressWarnings("unchecked")
+    private final BiFunction<String, String, String> function = mock(BiFunction.class);
+    private final Merge<Context, String, String, String> lifted = Merge.lift(function);
+
+    @Test
+    public void executesFunction() throws Exception {
+        doReturn("result").when(function).apply("left", "right");
+
+        assertThat(lifted.merge(context, "left", "right"), is("result"));
+
+        verify(function).apply("left", "right");
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("function failed");
+        doThrow(taskFailed).when(function).apply("left", "right");
+
+        try {
+            lifted.merge(context, "left", "right");
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(function).apply("left", "right");
+    }
+}

--- a/src/test/java/com/loginbox/transactor/transactable/QueryLiftTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/QueryLiftTest.java
@@ -1,0 +1,46 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class QueryLiftTest {
+    private final Context context = mock(Context.class);
+
+    @SuppressWarnings("unchecked")
+    private final Supplier<String> supplier = mock(Supplier.class);
+    private final Query<Context, String> lifted = Query.lift(supplier);
+
+    @Test
+    public void executesFunction() throws Exception {
+        doReturn("result").when(supplier).get();
+
+        assertThat(lifted.fetch(context), is("result"));
+
+        verify(supplier).get();
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("supplier failed");
+        doThrow(taskFailed).when(supplier).get();
+
+        try {
+            lifted.fetch(context);
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(supplier).get();
+    }
+}

--- a/src/test/java/com/loginbox/transactor/transactable/SinkLiftTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/SinkLiftTest.java
@@ -1,0 +1,43 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class SinkLiftTest {
+    private final Context context = mock(Context.class);
+
+    @SuppressWarnings("unchecked")
+    private final Consumer<String> consumer = mock(Consumer.class);
+    private final Sink<Context, String> lifted = Sink.lift(consumer);
+
+    @Test
+    public void executesFunction() throws Exception {
+        lifted.consume(context, "value");
+
+        verify(consumer).accept("value");
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("consumer failed");
+        doThrow(taskFailed).when(consumer).accept("value");
+
+        try {
+            lifted.consume(context, "value");
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(consumer).accept("value");
+    }
+}

--- a/src/test/java/com/loginbox/transactor/transactable/TransformLiftTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/TransformLiftTest.java
@@ -1,0 +1,46 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class TransformLiftTest {
+    private final Context context = mock(Context.class);
+
+    @SuppressWarnings("unchecked")
+    private final Function<String, String> function = mock(Function.class);
+    private final Transform<Context, String, String> lifted = Transform.lift(function);
+
+    @Test
+    public void executesFunction() throws Exception {
+        doReturn("result").when(function).apply("value");
+
+        assertThat(lifted.apply(context, "value"), is("result"));
+
+        verify(function).apply("value");
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("function failed");
+        doThrow(taskFailed).when(function).apply("value");
+
+        try {
+            lifted.apply(context, "value");
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(function).apply("value");
+    }
+}


### PR DESCRIPTION
Lifts convert non-transactable chunks of computation into transactable actions,
allowing them to be run in the context of a transaction. This also allows them
to be sequenced with other actions in a transaction, and to participate in
determining the final value of a transaction.

Providing explicit `lift` operations should help cut down on the need for dumb
code like

    Action<Context> action = context -> this.someVoidMethod();

in favour of

    Action<Context> action = lift(this::someVoidMethod);