### PR TITLE
Make `abort(C context)` and `finish(C context)` optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ from the rest of your program.
 A `Transactor<C>` manages contexts (objects of type `C`, which must implement
 `AutoCloseable`) for transactions, opening and closing them around each unit of
 work. Code using this library must subclass `Transactor` to specialize it for a
-specific kind of transaction. Subclasses provide three methods:
+specific kind of transaction. Subclasses one mandatory method:
 
 * `C createContext()` opens new transaction contexts. For example, a JDBC
     transactor might implement this as
@@ -55,6 +55,9 @@ specific kind of transaction. Subclasses provide three methods:
         public Connection createContext() throws SQLException {
             return dataSource.createConnection();
         }
+
+Subclasses may also provide either, both, or none of the two optional
+completion methods:
 
 * `void finish(C context)` handles finishing a successful transaction. For
     example, a JDBC transactor might implement this as
@@ -73,8 +76,8 @@ specific kind of transaction. Subclasses provide three methods:
             context.rollback();
         }
 
-Given these three methods, and an `AutoCloseable` context type, `Transactor`
-can manage units of work around "transactable" objects.
+Given these methods, `Transactor` can manage units of work around
+"transactable" processes.
 
 ## Transactables
 

--- a/src/main/java/com/loginbox/transactor/Transactor.java
+++ b/src/main/java/com/loginbox/transactor/Transactor.java
@@ -29,8 +29,9 @@ public abstract class Transactor<C extends AutoCloseable> {
     protected abstract C createContext() throws Exception;
 
     /**
-     * Invoked at the end of an execution to clean up the context if and only if the execution raises an exception. For
-     * example, a database Transactor would use this to roll back failed transactions.
+     * Invoked at the end of an execution to clean up the context if and only if the execution raises an exception. The
+     * default implementation is to do nothing when a transaction fails. Most applications will want to override this to
+     * perform cleanup actions, such as rolling back transactions.
      *
      * @param context
      *         the context for the execution. This will be the context previously obtained from {@link
@@ -41,11 +42,14 @@ public abstract class Transactor<C extends AutoCloseable> {
      *         {@link java.lang.AutoCloseable#close() close it}. This exception will be {@link Throwable#getSuppressed()
      *         suppressed} by the exception that caused the operation to abort in the first place.
      */
-    protected abstract void abort(C context) throws Exception;
+    protected void abort(C context) throws Exception {
+        /* by default, do nothing */
+    }
 
     /**
-     * Invoked at the end of an execution to clean up the context if and only if the execution completes normally. For
-     * example, a database Transactor would use this to commit successful transactions.
+     * Invoked at the end of an execution to clean up the context if and only if the execution completes normally. The
+     * default implementation is to do nothing when a transaction fails. Most applications will want to override this to
+     * perform post-success actions, such as committing transactions.
      *
      * @param context
      *         the context for the execution. This will be the context previously obtained from {@link
@@ -55,7 +59,9 @@ public abstract class Transactor<C extends AutoCloseable> {
      *         method as-is. Transactor itself makes no assumptions about whether the transaction is valid, but will
      *         still attempt to {@link java.lang.AutoCloseable#close() close it}.
      */
-    protected abstract void finish(C context) throws Exception;
+    protected void finish(C context) throws Exception {
+        /* by default, do nothing */
+    }
 
     /**
      * Runs an {@link com.loginbox.transactor.transactable.Action} in a new context.


### PR DESCRIPTION
For truly trivial contexts, such as those that appear in unit tests, the
callbacks are likely empty. Forcing people to implement empty methods is a
waste of everyone's time and goodwill.