### PR TITLE
Defined "pivot" operators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,26 @@ The following types can be lifted:
 * `Function` can be lifted to `Transform`.
 * `BiFunction` can be lifted to `Merge`.
 
+## Pivots
+
+Transactables with at least one argument can be pivoted, swapping an argument
+for the context value. This can be useful when the nominal context is a
+positional argument of a lifted method. For example, suppose that the method
+handle `User::register` can be lifted to a `Sink<User, Database>`, whose
+context type is `User`. This `Sink` can then be pivoted to give a
+`Sink<Database, User>`, which is more likely to fit into a chain of
+transactables applied to a database.
+
+The following pivots are defined:
+
+* `Sink`s and `Transform`s can be `pivot()`ed to replace their sole input with
+    their context.
+
+* `Merge`s can be `pivotLeft()`ed to swap the left argument with the context,
+    `pivotRight()`ed to swap the right argument with the context, and
+    `transpose()`d to swap the two arguments in place without exchanging the
+    context.
+
 ## A Small Example
 
 An example, for basic JDBC. First, we define a transactor. This might be

--- a/src/main/java/com/loginbox/transactor/transactable/Sink.java
+++ b/src/main/java/com/loginbox/transactor/transactable/Sink.java
@@ -42,6 +42,16 @@ public interface Sink<C, V> {
     public void consume(C context, V value) throws Exception;
 
     /**
+     * Pivots this sink's context and argument. Given a sink with context C and argument V, returns a new sink with
+     * context V and argument C.
+     *
+     * @return the pivoted version of this sink.
+     */
+    public default Sink<V, C> pivot() {
+        return (context, value) -> consume(value, context);
+    }
+
+    /**
      * Sequence this sink before another action.
      *
      * @param next
@@ -62,7 +72,8 @@ public interface Sink<C, V> {
      *         the query to evaluate after this sink.
      * @param <R>
      *         the result type of the query, and the resulting transform.
-     * @return a new composite transform that executes this sink to consume the input value, and then fetches the resulting value using <var>query</var>.
+     * @return a new composite transform that executes this sink to consume the input value, and then fetches the
+     * resulting value using <var>query</var>.
      */
     public default <R> Transform<C, V, R> before(Query<? super C, ? extends R> query) {
         return (context, value) -> {

--- a/src/main/java/com/loginbox/transactor/transactable/Transform.java
+++ b/src/main/java/com/loginbox/transactor/transactable/Transform.java
@@ -48,6 +48,16 @@ public interface Transform<C, I, O> {
     public O apply(C context, I value) throws Exception;
 
     /**
+     * Pivots this transform's context and argument. Given a transform in context C with argument I, produces a new
+     * transform in context I with argument C.
+     *
+     * @return the pivoted transform.
+     */
+    public default Transform<I, C, O> pivot() {
+        return (context, input) -> apply(input, context);
+    }
+
+    /**
      * Sequence this transform before another action.
      *
      * @param next

--- a/src/test/java/com/loginbox/transactor/transactable/MergePivotLeftTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/MergePivotLeftTest.java
@@ -1,0 +1,47 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import com.loginbox.transactor.Transactables;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class MergePivotLeftTest {
+    private final Transactables transactables = mock(Transactables.class);
+
+    private final Context context = mock(Context.class);
+
+    @SuppressWarnings("unchecked")
+    private final Merge<Context, String, String, String> original = transactables::merge;
+    private final Merge<String, Context, String, String> pivoted = original.pivotLeft();
+
+    @Test
+    public void executesFunction() throws Exception {
+        doReturn("result").when(transactables).merge(context, "left", "right");
+
+        assertThat(pivoted.merge("left", context, "right"), is("result"));
+
+        verify(transactables).merge(context, "left", "right");
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("merge failed");
+        doThrow(taskFailed).when(transactables).merge(context, "left", "right");
+
+        try {
+            pivoted.merge("left", context, "right");
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(transactables).merge(context, "left", "right");
+    }
+}

--- a/src/test/java/com/loginbox/transactor/transactable/MergePivotRightTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/MergePivotRightTest.java
@@ -1,0 +1,47 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import com.loginbox.transactor.Transactables;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class MergePivotRightTest {
+    private final Transactables transactables = mock(Transactables.class);
+
+    private final Context context = mock(Context.class);
+
+    @SuppressWarnings("unchecked")
+    private final Merge<Context, String, String, String> original = transactables::merge;
+    private final Merge<String, String, Context, String> pivoted = original.pivotRight();
+
+    @Test
+    public void executesFunction() throws Exception {
+        doReturn("result").when(transactables).merge(context, "left", "right");
+
+        assertThat(pivoted.merge("right", "left", context), is("result"));
+
+        verify(transactables).merge(context, "left", "right");
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("merge failed");
+        doThrow(taskFailed).when(transactables).merge(context, "left", "right");
+
+        try {
+            pivoted.merge("right", "left", context);
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(transactables).merge(context, "left", "right");
+    }
+}

--- a/src/test/java/com/loginbox/transactor/transactable/MergeTransposeTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/MergeTransposeTest.java
@@ -1,0 +1,47 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import com.loginbox.transactor.Transactables;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class MergeTransposeTest {
+    private final Transactables transactables = mock(Transactables.class);
+
+    private final Context context = mock(Context.class);
+
+    @SuppressWarnings("unchecked")
+    private final Merge<Context, String, String, String> original = transactables::merge;
+    private final Merge<Context, String, String, String> pivoted = original.transpose();
+
+    @Test
+    public void executesFunction() throws Exception {
+        doReturn("result").when(transactables).merge(context, "left", "right");
+
+        assertThat(pivoted.merge(context, "right", "left"), is("result"));
+
+        verify(transactables).merge(context, "left", "right");
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("merge failed");
+        doThrow(taskFailed).when(transactables).merge(context, "left", "right");
+
+        try {
+            pivoted.merge(context, "right", "left");
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(transactables).merge(context, "left", "right");
+    }
+}

--- a/src/test/java/com/loginbox/transactor/transactable/SinkPivotTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/SinkPivotTest.java
@@ -1,0 +1,44 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import com.loginbox.transactor.Transactables;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class SinkPivotTest {
+    private final Transactables transactables = mock(Transactables.class);
+
+    private final Context context = mock(Context.class);
+
+    @SuppressWarnings("unchecked")
+    private final Sink<Context, String> original = transactables::sink;
+    private final Sink<String, Context> pivoted = original.pivot();
+
+    @Test
+    public void executesFunction() throws Exception {
+        pivoted.consume("value", context);
+
+        verify(transactables).sink(context, "value");
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("sink failed");
+        doThrow(taskFailed).when(transactables).sink(context, "value");
+
+        try {
+            pivoted.consume("value", context);
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(transactables).sink(context, "value");
+    }
+}

--- a/src/test/java/com/loginbox/transactor/transactable/TransformPivotTest.java
+++ b/src/test/java/com/loginbox/transactor/transactable/TransformPivotTest.java
@@ -1,0 +1,49 @@
+package com.loginbox.transactor.transactable;
+
+import com.loginbox.transactor.Context;
+import com.loginbox.transactor.Transactables;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransformPivotTest {
+    private final Transactables transactables = mock(Transactables.class);
+
+    private final Context context = mock(Context.class);
+
+    private final Transform<Context, String, String> original = transactables::transform;
+    private final Transform<String, Context, String> pivoted = original.pivot();
+
+    @Test
+    public void executesFunction() throws Exception {
+        doReturn("result").when(transactables).transform(context, "value");
+
+        assertThat(pivoted.apply("value", context), is("result"));
+
+        verify(transactables).transform(context, "value");
+    }
+
+    @Test
+    public void propagatesFailures() throws Exception {
+        RuntimeException taskFailed = new RuntimeException("transform failed");
+        doThrow(taskFailed).when(transactables).transform(context, "value");
+
+        try {
+            pivoted.apply("value", context);
+            fail();
+        } catch (RuntimeException caught) {
+            assertThat(caught, is(taskFailed));
+        }
+
+        verify(transactables).transform(context, "value");
+    }
+}


### PR DESCRIPTION
Pivots transpose the arguments of a transactable with the context, producing a new transactable whose context was the original's argument (and vice versa). The primary motivation is to enable the use of method handles as transactables when the handle may have been obtained via the class, rather than via a specific instance.

For a complete description, see the changes to `README.md`.